### PR TITLE
Revert "DDCE-6670: Kosovo country added in both English and Welsh."

### DIFF
--- a/conf/location-autocomplete-canonical-list.json
+++ b/conf/location-autocomplete-canonical-list.json
@@ -1,9 +1,5 @@
 [
   [
-    "Kosovo",
-    "country:XK"
-  ],
-  [
     "Andorra",
     "country:AD"
   ],

--- a/conf/location-canonical-list-nonUK.json
+++ b/conf/location-canonical-list-nonUK.json
@@ -1,9 +1,5 @@
 [
   [
-    "Kosovo",
-    "country:XK"
-  ],
-  [
     "Andorra",
     "country:AD"
   ],


### PR DESCRIPTION
Reverts hmrc/register-estate-personal-rep-frontend#116